### PR TITLE
Implement getAllValidators, getValidator in SDK

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,22 @@
+/*******************************************************************************
+
+    This is the main file for exporting classes and functions provided
+    by the BOA SDK.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+export { readFromString, writeToString } from './modules/utils/buffer';
+export { Hash, hash, hashMulti, makeUTXOKey } from './modules/data/Hash';
+export { PreImage  } from './modules/data/PreImage';
+export { PublicKey } from './modules/data/PublicKey';
+export { Signature } from './modules/data/Signature';
+export { Validator } from './modules/data/Validator';
+
+export { BOAClient } from './modules/net/BOAClient';

--- a/src/modules/data/PreImage.ts
+++ b/src/modules/data/PreImage.ts
@@ -1,0 +1,70 @@
+/*******************************************************************************
+
+    Contains definition for the pre-image
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import { Hash }  from './Hash';
+import { validateJSON } from '../utils/json';
+
+/**
+ * Define the pre-image
+ */
+export class PreImage
+{
+    /**
+     * The value of the pre-image at the distance from the commitment
+     */
+    hash: Hash;
+
+    /**
+     * The distance between this pre-image and the initial commitment
+     */
+    distance: number;
+
+    /**
+     * Constructor
+     * @param h {Hash | undefined} The value of the pre-image at the distance from the commitment
+     * @param d {number | undefined} The distance between this pre-image and the initial commitment
+     */
+    constructor (h?: Hash, d?: number)
+    {
+        if (h != undefined)
+            this.hash = new Hash(h.data);
+        else
+            this.hash = new Hash();
+
+        if (d != undefined)
+            this.distance = d;
+        else
+            this.distance = 0;
+    }
+
+    /**
+     * This import from JSON
+     * @param data {JSONPreImage} The object of the JSON
+     */
+    public fromJSON (data: JSONPreImage)
+    {
+        validateJSON(this, data);
+
+        this.distance = data.distance;
+        this.hash.fromString(data.hash);
+    }
+}
+
+/**
+ * Define the pre-image in JSON
+ */
+export interface JSONPreImage
+{
+    hash: string;
+    distance: number;
+}

--- a/src/modules/data/Validator.ts
+++ b/src/modules/data/Validator.ts
@@ -1,0 +1,97 @@
+/*******************************************************************************
+
+    Contains definition for the validator
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import { Hash }  from './Hash';
+import { PreImage, JSONPreImage } from './PreImage';
+import { validateJSON } from '../utils/json';
+
+/**
+ * Define the validator
+ */
+export class Validator
+{
+    /**
+     * The public key that is included in the frozen UTXO.
+     */
+    address: string;
+
+    /**
+     * The block height when enrolled
+     */
+    enrolled_at: number;
+
+    /**
+     * The hash of frozen UTXO
+     */
+    stake: Hash;
+
+    /**
+     * The pre-image
+     */
+    preimage: PreImage;
+
+    /**
+     * Constructor
+     * @param address {string | undefined} The public key that is included in the frozen UTXO.
+     * @param height {number | undefined} The block height when enrolled
+     * @param stake {Hash | undefined} The hash of frozen UTXO
+     * @param image {PreImage | undefined} The pre-image
+     */
+    constructor(address?: string, height?: number, stake?: Hash, image?: PreImage)
+    {
+        if (address != undefined)
+            this.address = address;
+        else
+            this.address = '';
+
+        if (height != undefined)
+            this.enrolled_at = height;
+        else
+            this.enrolled_at = 0;
+
+        if (stake != undefined)
+            this.stake = stake;
+        else
+            this.stake = new Hash();
+
+        if (image != undefined)
+            this.preimage = image;
+        else
+            this.preimage = new PreImage();
+    }
+
+    /**
+     * This import from JSON
+     * @param data {JSONValidator} The object of the JSON
+     */
+    public fromJSON (data: JSONValidator)
+    {
+        validateJSON(this, data);
+
+        this.address = data.address;
+        this.enrolled_at = data.enrolled_at;
+        this.stake.fromString(data.stake);
+        this.preimage.fromJSON(data.preimage);
+    }
+}
+
+/**
+ * Define the validator in JSON
+ */
+export interface JSONValidator
+{
+    address: string;
+    enrolled_at: number;
+    stake: string;
+    preimage: JSONPreImage;
+}

--- a/src/modules/net/Request.ts
+++ b/src/modules/net/Request.ts
@@ -1,0 +1,23 @@
+/*******************************************************************************
+
+    Contains instances of requesting data from the server
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import axios from 'axios';
+
+const Request = axios.create(
+    {
+        headers: {
+            "User-Agent": "boa-sdk-ts"
+        },
+    });
+
+export default Request;

--- a/src/modules/utils/json.ts
+++ b/src/modules/utils/json.ts
@@ -1,0 +1,28 @@
+/*******************************************************************************
+
+    Contains validation of JSON data
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+/**
+ * This checks that the JSON data has all the properties of the class.
+ * @param obj {Object} The instance of a class
+ * @param json {any} The object of the JSON
+ */
+export function validateJSON (obj: Object, json: any)
+{
+    Object.getOwnPropertyNames(obj)
+        .forEach(property => {
+            if (!json.hasOwnProperty(property))
+            {
+                throw new Error('Parse error: ' + obj.constructor.name + '.' + property);
+            }
+        });
+}

--- a/tests/BOASDK.test.ts
+++ b/tests/BOASDK.test.ts
@@ -13,6 +13,7 @@
 
 import { Hash, hash } from '../src/modules/data/Hash';
 import { BOAClient } from '../src/modules/net/BOAClient';
+import { Validator } from '../src/modules/data/Validator';
 
 import * as assert from 'assert';
 import express from "express";
@@ -188,17 +189,211 @@ describe ('BOA SDK', () =>
             doneIt();
         });
     });
-});
 
-describe ('BOA SDK', () =>
-{
+    it ('Test a function of the BOA SDK - `getAllValidators`', (doneIt: () => void) =>
+    {
+        // Set URL
+        let uri = URI("http://localhost").port(port);
+
+        // Create BOA SDK
+        let sdk = new BOAClient(uri.toString());
+
+        // Query
+        sdk.getAllValidators(10)
+        .then((validators: Array<Validator>) =>
+        {
+            // On Success
+            assert.strictEqual(validators.length, 3);
+            assert.strictEqual(validators[0].address, "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN");
+            assert.strictEqual(validators[0].preimage.distance, 10);
+
+            // end of this test
+            doneIt();
+        })
+        .catch(err =>
+        {
+            // On Error
+            assert.ok(!err, err);
+
+            // end of this test
+            doneIt();
+        });
+    });
+
+    it ('Test a function of the BOA SDK - `getAllValidator`', (doneIt: () => void) =>
+    {
+        // Set URL
+        let uri = URI("http://localhost").port(port);
+
+        // Create BOA SDK
+        let sdk = new BOAClient(uri.toString());
+
+        // Query
+        sdk.getValidator("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", 10)
+        .then((validators: Array<Validator>) =>
+        {
+            // On Success
+            assert.strictEqual(validators.length, 1);
+            assert.strictEqual(validators[0].address, "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN");
+            assert.strictEqual(validators[0].preimage.distance, 10);
+
+            // end of this test
+            doneIt();
+        })
+        .catch(err =>
+        {
+            // On Error
+            assert.ok(!err, err);
+
+            // end of this test
+            doneIt();
+        });
+    });
+
+    it ('Test a function of the BOA SDK using async, await - `getAllValidators`', async () =>
+    {
+        // Set URL
+        let uri = URI("http://localhost").port(port);
+
+        // Create BOA SDK
+        let sdk = new BOAClient(uri.toString());
+
+        // Query
+        try
+        {
+            let validators = await sdk.getAllValidators(10);
+            // On Success
+            assert.strictEqual(validators.length, 3);
+            assert.strictEqual(validators[0].address, "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN");
+            assert.strictEqual(validators[0].preimage.distance, 10);
+        }
+        catch (err)
+        {
+            // On Error
+            assert.ok(!err, err);
+        }
+    });
+
+    it ('Test a function of the BOA SDK using async, await - `getAllValidator`', async () =>
+    {
+        // Set URL
+        let uri = URI("http://localhost").port(port);
+
+        // Create BOA SDK
+        let sdk = new BOAClient(uri.toString());
+
+        // Query
+        try
+        {
+            let validators = await sdk.getValidator("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", 10);
+
+            // On Success
+            assert.strictEqual(validators.length, 1);
+            assert.strictEqual(validators[0].address, "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN");
+            assert.strictEqual(validators[0].preimage.distance, 10);
+        }
+        catch (err)
+        {
+            // On Error
+            assert.ok(!err, err);
+        }
+    });
+
+    it ('When none of the data exists as a result of the inquiry.', (doneIt: () => void) =>
+    {
+        // Set URL
+        let uri = URI("http://localhost").port(port);
+
+        // Create BOA SDK
+        let sdk = new BOAClient(uri.toString());
+
+        // Query
+        sdk.getValidator("GX3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", 10)
+            .then((validators: Array<Validator>) =>
+            {
+                // On Success
+                assert.strictEqual(validators.length, 0);
+
+                // end of this test
+                doneIt();
+            })
+            .catch(err =>
+            {
+                // On Error
+                assert.fail(err);
+
+                // end of this test
+                doneIt();
+            });
+    });
+
+    it ('When an error occurs with the wrong input parameter (height is -10).', (doneIt: () => void) =>
+    {
+        // Set URL
+        let uri = URI("http://localhost").port(port);
+
+        // Create BOA SDK
+        let sdk = new BOAClient(uri.toString());
+
+        // Query
+        sdk.getValidator("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", -10)
+            .then((validators: Array<Validator>) =>
+            {
+                // On Success
+                assert.ok(false, "A different case occurred than expected.")
+
+                // end of this test
+                doneIt();
+            })
+            .catch(err =>
+            {
+                // On Error
+                assert.strictEqual(err.message, "Bad Request, The Height value is not valid.");
+
+                // end of this test
+                doneIt();
+            });
+    });
+
+    it ('Can not connect to the server by entering the wrong URL', (doneIt: () => void) =>
+    {
+        // Set URL
+        let uri = URI("http://localhost").port("6000");
+
+        // Create BOA SDK
+        let sdk = new BOAClient(uri.toString());
+
+        // Query
+        sdk.getValidator("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", 10)
+            .then((validators: Array<Validator>) =>
+            {
+                // On Success
+                assert.ok(false, "A different case occurred than expected.")
+
+                // end of this test
+                doneIt();
+            })
+            .catch(err =>
+            {
+                // On Error
+                assert.strictEqual(err.message, "connect ECONNREFUSED 127.0.0.1:6000");
+
+                // end of this test
+                doneIt();
+            });
+    });
+
     /**
      * See_Also: https://github.com/bpfkorea/agora/blob/
      * 93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/consensus/validation/PreImage.d#L79-L106
      */
     it ('test for validity of pre-image', (doneIt: () => void) =>
     {
-        let sdk = new BOAClient();
+        // Set URL
+        let uri = URI("http://localhost").port(port);
+
+        // Create BOA SDK
+        let sdk = new BOAClient(uri.toString());
 
         let pre_images: Hash[] = [];
         pre_images.push(hash(randomBytes(Hash.Width)));


### PR DESCRIPTION
I made an SDK function that connects to the Stoa server and requests and receives data using the http protocol.
In typescript, these functions are asynchronous.
In other words, the data does not come as soon as the request is made. The data arrive after a certain period of time.
TypeScript is written under the condition that it uses only a single CPU. Therefore, responses to the data can be received through callback or `Promise`.
I used a more efficient `Promise` here.
And I wrote the test code using `async / await`.

Related to bpfkorea/stoa#30