### PR TITLE
Fix links to Agora sources in a document

### DIFF
--- a/src/modules/data/Hash.ts
+++ b/src/modules/data/Hash.ts
@@ -77,7 +77,7 @@ export function hash (source: Buffer): Hash
  * @param source1 Original for creating hash
  * @param source2 Original for creating hash
  * @returns Instance of Hash
- * See_Also https://github.com/bpfkorea/agora/blob/v0.x.x/source/agora/common/Hash.d#L239-L255
+ * See_Also https://github.com/bpfkorea/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/Hash.d#L239-L255
  */
 export function hashMulti (source1: Buffer, source2: Buffer): Hash
 {
@@ -95,7 +95,7 @@ export function hashMulti (source1: Buffer, source2: Buffer): Hash
  * @param h {Hash} Hash of transaction
  * @param index {number | string} Index of the output
  * @returns Instance of Hash
- * See_Also https://github.com/bpfkorea/agora/blob/v0.x.x/source/agora/consensus/data/UTXOSetValue.d#L50-L53
+ * See_Also https://github.com/bpfkorea/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/consensus/data/UTXOSetValue.d#L50-L53
  */
 export function makeUTXOKey (h: Hash, index: number | string | object): Hash
 {

--- a/src/modules/data/PublicKey.ts
+++ b/src/modules/data/PublicKey.ts
@@ -2,8 +2,7 @@
 
     Contains definition for the public key class,
 
-    See_Also: https://github.com/bpfkorea/agora/blob/
-    93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/crypto/Key.d
+    See_Also: https://github.com/bpfkorea/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/crypto/Key.d
 
     Copyright:
         Copyright (c) 2020 BOS Platform Foundation Korea
@@ -86,8 +85,7 @@ export class PublicKey
      * @param signature {Signature} The signature of `msg` matching `this` public key.
      * @param msg {Buffer} The signed message. Should not include the signature.
      * @returns {boolean} `true` if the signature is valid
-     * See_Also: https://github.com/bpfkorea/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d
-     *  /source/agora/common/crypto/Key.d#L226-L235
+     * See_Also: https://github.com/bpfkorea/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/crypto/Key.d#L226-L235
      */
     public verify (signature: Signature, msg: Buffer): boolean
     {

--- a/src/modules/net/BOAClient.ts
+++ b/src/modules/net/BOAClient.ts
@@ -152,8 +152,7 @@ export class BOAClient
      * @returns {IsValidPreimageResponse}
      * {result: true, message: "The pre-image is valid."} if the pre-image is valid,
      * otherwise the result is false and the message is the reason for invalid
-     * See_Also: https://github.com/bpfkorea/agora/blob/
-     * 93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/consensus/validation/PreImage.d#L50-L69
+     * See_Also: https://github.com/bpfkorea/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/consensus/validation/PreImage.d#L50-L69
      */
     public isValidPreimage (
         original_image: Hash, original_image_height: number,

--- a/src/modules/utils/CRC16.ts
+++ b/src/modules/utils/CRC16.ts
@@ -31,8 +31,7 @@ import * as assert from 'assert';
  * Data returned is in little endian
  * @param data {Buffer} Input data
  * @returns {Buffer}
- * See_Also: https://github.com/bpfkorea/agora/blob/
- * 93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/crypto/Crc16.d#L90-L100
+ * See_Also: https://github.com/bpfkorea/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/crypto/Crc16.d#L90-L100
  */
 export function checksum (data: Buffer): Buffer
 {
@@ -47,8 +46,7 @@ export function checksum (data: Buffer): Buffer
  * @param data {Buffer} Data to checksum
  * @param expected {Buffer} Expected checksum value
  * @returns {boolean}
- * See_Also: https://github.com/bpfkorea/agora/blob/
- * 93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/crypto/Crc16.d#L104-L109
+ * See_Also: https://github.com/bpfkorea/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/crypto/Crc16.d#L104-L109
  */
 export function validate (data: Buffer, expected: Buffer): boolean
 {

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -381,8 +381,7 @@ describe ('BOA Client', () =>
     });
 
     /**
-     * See_Also: https://github.com/bpfkorea/agora/blob/
-     * 93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/consensus/validation/PreImage.d#L79-L106
+     * See_Also: https://github.com/bpfkorea/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/consensus/validation/PreImage.d#L79-L106
      */
     it ('test for validity of pre-image', (doneIt: () => void) =>
     {


### PR DESCRIPTION
The link connected two lines into one.
Change link to commit hash instead of branch name


#Relates to #30 