### PR TITLE
Remove an unused import

### DIFF
--- a/tests/Hash.test.ts
+++ b/tests/Hash.test.ts
@@ -14,7 +14,6 @@
 import * as boasdk from '../lib';
 
 import * as assert from 'assert';
-import { default as JSBI } from 'jsbi';
 
 describe('Hash', () => {
 


### PR DESCRIPTION
I removed an unused import.

~The test codes use an already compiled SDK.~
~However, the error is displayed in a specific editor.~
~I added '@ts-ignore' so that compilers ignore this code because it is already compiled.~
