### PR TITLE
Replace deprecated functions with available functions

### DIFF
--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -197,9 +197,9 @@ describe ('BOA Client', () =>
         client.get (uri.toString())
         .then((response) =>
         {
-            assert.equal(response.data.length, 1);
-            assert.equal(response.data[0].address, "GBJABNUCDJCIL5YJQMB5OZ7VCFPKYLMTUXM2ZKQJACT7PXL7EVOMEKNZ");
-            assert.equal(response.data[0].preimage.distance, 10);
+            assert.strictEqual(response.data.length, 1);
+            assert.strictEqual(response.data[0].address, "GBJABNUCDJCIL5YJQMB5OZ7VCFPKYLMTUXM2ZKQJACT7PXL7EVOMEKNZ");
+            assert.strictEqual(response.data[0].preimage.distance, 10);
 
             doneIt();
         })

--- a/tests/Hash.test.ts
+++ b/tests/Hash.test.ts
@@ -40,7 +40,7 @@ describe('Hash', () => {
             '3dc369ef2a44b62ba113814a9d819a276ff61582874c9aee9c98efa2aa1f10d73');
 
         // Check
-        assert.equal(h.toString(),
+        assert.strictEqual(h.toString(),
             '0x5d7f6a7a30f7ff591c8649f61eb8a35d034824ed5cd252c2c6f10cdbd2236713d' +
             'c369ef2a44b62ba113814a9d819a276ff61582874c9aee9c98efa2aa1f10d73');
     });
@@ -50,7 +50,7 @@ describe('Hash', () => {
         let h = boasdk.hash(Buffer.from("abc"));
 
         // Check
-        assert.equal(h.toString(),
+        assert.strictEqual(h.toString(),
             '0x239900d4ed8623b95a92f1dba88ad31895cc3345ded552c22d79ab2a39c5877' +
             'dd1a2ffdb6fbb124bb7c45a68142f214ce9f6129fb697276a0d4d1c983fa580ba');
     });
@@ -67,7 +67,7 @@ describe('Hash', () => {
         let h = boasdk.hashMulti(foo.data, bar.data);
 
         // Check
-        assert.equal(h.toString(),
+        assert.strictEqual(h.toString(),
             '0xe0343d063b14c52630563ec81b0f91a84ddb05f2cf05a2e4330ddc79bd3a06e57' +
             'c2e756f276c112342ff1d6f1e74d05bdb9bf880abd74a2e512654e12d171a74');
     });
@@ -78,7 +78,7 @@ describe('Hash', () => {
             '3dc369ef2a44b62ba113814a9d819a276ff61582874c9aee9c98efa2aa1f10d73');
         //let hash = boasdk.makeUTXOKey(tx_hash, JSBI.BigInt(1));
         let hash = boasdk.makeUTXOKey(tx_hash, boasdk.JSBInt.BigInt(1));
-        assert.equal(hash,
+        assert.strictEqual(hash.toString(),
             '0x7c95c29b184e47fbd32e58e5abd42c6e22e8bd5a7e934ab049d21df545e09c2' +
             'e33bb2b89df2e59ee01eb2519b1508284b577f66a76d42546b65a6813e592bb84');
     });


### PR DESCRIPTION
I replaced a deprecated function with an available function

`assert.equal` is a deprecated function, and the alternative function is `assert.strictEqual`.
