### PR TITLE
Change the name of API from `registerVoteData` to `saveData`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "The TypeScript BOA SDK libary",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/modules/net/BOAClient.ts
+++ b/src/modules/net/BOAClient.ts
@@ -224,14 +224,14 @@ export class BOAClient
     }
 
     /**
-     * Register the vote data
+     * Saves the data to the blockchain
      * @param inputs An array of 1 or more UTXOs to be spent
      * @param outputs An array of 1 or more output
      * @param keys An array of length matching `inputs` which are the keys controlling the UTXOs
      * @param data The data to store
      * @returns Returns true if success, otherwise returns false
      */
-    public registerVoteData (inputs: Array<TxInput>, outputs: Array<TxOutput>, keys: Array<Seed>, data: Buffer): Promise<boolean>
+    public saveData (inputs: Array<TxInput>, outputs: Array<TxOutput>, keys: Array<Seed>, data: Buffer): Promise<boolean>
     {
         return new Promise<boolean>((resolve, reject) =>
         {

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -649,7 +649,7 @@ describe ('BOA Client', () =>
         }
     });
 
-    it ('Test sending a vote data', async () =>
+    it ('Test saving a vote data', async () =>
     {
         // Set URL
         let uri = URI("http://localhost").port(port);
@@ -660,7 +660,7 @@ describe ('BOA Client', () =>
 
         try
         {
-            let res = await boa_client.registerVoteData(
+            let res = await boa_client.saveData(
                 [
                     new boasdk.TxInput(
                         boasdk.Hash.createFromString("0x81a326afa790003c32517a2a" +


### PR DESCRIPTION
The name is changed because other data can be stored in addition to voting data.