### PR TITLE
Change `.npmignore` to be built when installed

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,4 @@
 *.iml
 *.log
 node_modules/
-tsconfig.json
 tslint.json


### PR DESCRIPTION
If the module is installed in another project, tsconfig.json is required to run the builder.
So, remove tsconfig.json from .npmignore.