### PR TITLE
Enhance error handling to make it easier to access error messages from Stoa

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,5 @@ export { PreImage  } from './modules/net/response/PreImage';
 
 export { BOAClient } from './modules/net/BOAClient';
 export { Request } from './modules/net/Request';
+
+export { NetworkError, NotFoundError, BadRequestError } from './modules/net/error/ErrorTypes';

--- a/src/modules/net/error/ErrorTypes.ts
+++ b/src/modules/net/error/ErrorTypes.ts
@@ -1,0 +1,84 @@
+/*******************************************************************************
+
+    Contains definition for error types
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+/**
+ * The class used when a network error occurs
+ */
+export class NetworkError extends Error
+{
+    /**
+     * The status code
+     */
+    public status: number;
+
+    /**
+     * The status text
+     */
+    public statusText: string;
+
+    /**
+     * The message of response
+     */
+    public statusMessage: string;
+
+    /**
+     * Constructor
+     * @param status        The status code
+     * @param statusText    The status text
+     * @param statusMessage The message of response
+     */
+    constructor (status: number, statusText: string, statusMessage: string)
+    {
+        super(statusText);
+        this.name = 'NetworkError';
+        this.status = status;
+        this.statusText = statusText;
+        this.statusMessage = statusMessage;
+    }
+}
+
+/**
+ *  When status code is 404
+ */
+export class NotFoundError extends NetworkError
+{
+    /**
+     * Constructor
+     * @param status        The status code
+     * @param statusText    The status text
+     * @param statusMessage The message of response
+     */
+    constructor (status: number, statusText: string, statusMessage: string)
+    {
+        super(status, statusText, statusMessage);
+        this.name = 'NotFoundError';
+    }
+}
+
+/**
+ *  When status code is 400
+ */
+export class BadRequestError extends NetworkError
+{
+    /**
+     * Constructor
+     * @param status        The status code
+     * @param statusText    The status text
+     * @param statusMessage The message of response
+     */
+    constructor (status: number, statusText: string, statusMessage: string)
+    {
+        super(status, statusText, statusMessage);
+        this.name = 'BadRequestError';
+    }
+}

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -654,10 +654,12 @@ describe ('BOA Client', () =>
                 // end of this test
                 doneIt();
             })
-            .catch((err: any) =>
+            .catch((err: boasdk.NetworkError) =>
             {
                 // On Error
-                assert.strictEqual(err.message, "Bad Request, The Height value is not valid.");
+                assert.strictEqual(err.status, 400);
+                assert.strictEqual(err.message, "Bad Request");
+                assert.strictEqual(err.statusMessage, "The Height value is not valid.");
 
                 // end of this test
                 doneIt();


### PR DESCRIPTION
If an error occurs in HTTP communication, status and statusText are available.
However, it is difficult to use customized messages from a server in SDK.

I create this PR to make the error messages delivered by the server easier to access.