### PR TITLE
Fix schema to be used in JSON validator

### DIFF
--- a/src/modules/utils/JSONValidator.ts
+++ b/src/modules/utils/JSONValidator.ts
@@ -110,7 +110,9 @@ export class JSONValidator
                     "merkle_root",
                     "validators",
                     "signature",
-                    "enrollments"
+                    "enrollments",
+                    "random_seed",
+                    "missing_validators"
                 ]
             }
         ],


### PR DESCRIPTION
Two missing fields were added where the JSON schema defines the required fields.