### PR TITLE
Add a validate function for Public Key

### DIFF
--- a/src/modules/common/KeyPair.ts
+++ b/src/modules/common/KeyPair.ts
@@ -131,6 +131,29 @@ export class PublicKey
     }
 
     /**
+     * Verify the public key with a string for normal.
+     * @param address Representing the public key as a string
+     * @returns If the address passes the validation, it returns an empty string or a message.
+     */
+    public static validate (address: string): string
+    {
+        const decoded = Buffer.from(base32Decode(address));
+
+        if (decoded.length != 1 + SodiumHelper.sodium.crypto_sign_PUBLICKEYBYTES + 2)
+            return 'Decoded data size is not normal';
+
+        if (decoded[0] != VersionByte.AccountID)
+            return 'This is not a valid address type';
+
+        const body = decoded.slice(0, -2);
+        const checksum = decoded.slice(-2);
+        if (!validate(body, checksum))
+            return 'Checksum result do not match';
+
+        return '';
+    }
+
+    /**
      * Uses Stellar's representation instead of hex
      */
     public toString (): string

--- a/tests/KeyPair.test.ts
+++ b/tests/KeyPair.test.ts
@@ -29,6 +29,20 @@ describe ('ED25519 Public Key', () =>
         let public_key = new boasdk.PublicKey(address);
         assert.strictEqual(public_key.toString(), address);
     });
+
+    it ('Test of PublicKey.validate()', () =>
+    {
+        assert.strictEqual(boasdk.PublicKey.validate("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQF"), 'Decoded data size is not normal');
+        assert.strictEqual(boasdk.PublicKey.validate("SDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"), 'This is not a valid address type');
+        assert.strictEqual(boasdk.PublicKey.validate("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"), '');
+
+        const decoded = Buffer.from(base32Decode("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"));
+        const body = decoded.slice(0, -2);
+        const checksum = decoded.slice(-2);
+        let invalid_decoded = Buffer.concat([body, checksum.map(n => ~n)]);
+        let invalid_address = base32Encode(invalid_decoded);
+        assert.strictEqual(boasdk.PublicKey.validate(invalid_address), 'Checksum result do not match');
+    });
 });
 
 describe ('ED25519 Secret Key Seed', () =>


### PR DESCRIPTION
This function is required to check the received address on HTTP requests.

Relates to https://github.com/bpfkorea/boa-sdk-ts/issues/85