### PR TITLE
Change the block timestamp type to number

### DIFF
--- a/src/modules/data/BlockHeader.ts
+++ b/src/modules/data/BlockHeader.ts
@@ -71,7 +71,7 @@ export class BlockHeader
     /**
      * Block unix timestamp
      */
-    public timestamp: bigint;
+    public timestamp: number;
 
     /**
      * Constructor
@@ -86,7 +86,7 @@ export class BlockHeader
      * @param timestamp Block unix timestamp
      */
     constructor (prev_block: Hash, height: Height, merkle_root: Hash,
-        validators: BitField, signature: Signature, enrollments: Enrollment[], random_seed: Hash, missing_validators: Array<number>, timestamp: bigint)
+        validators: BitField, signature: Signature, enrollments: Enrollment[], random_seed: Hash, missing_validators: Array<number>, timestamp: number)
     {
         this.prev_block = prev_block;
         this.height = height;
@@ -124,7 +124,7 @@ export class BlockHeader
             value.enrollments.map((elem: any) => Enrollment.reviver("", elem)),
             new Hash(value.random_seed),
             value.missing_validators.map((elem: number) => elem),
-            BigInt(value.timestamp)
+            value.timestamp
         );
     }
 
@@ -143,7 +143,7 @@ export class BlockHeader
         for (let elem of this.missing_validators)
             buffer.writeUInt32LE(elem);
         const buf = Buffer.allocUnsafe(8);
-        Utils.writeBigIntLE(buf, this.timestamp);
+        Utils.writeBigIntLE(buf, BigInt(this.timestamp));
         buffer.writeBuffer(buf);
     }
 }

--- a/tests/Hash.test.ts
+++ b/tests/Hash.test.ts
@@ -128,7 +128,7 @@ describe('Hash', () =>
             [ ],
             new boasdk.Hash(Buffer.alloc(boasdk.Hash.Width)),
             [ ],
-            BigInt(0)
+            0
         );
         assert.strictEqual(boasdk.hashFull(header).toString(),
             "0x110c703c994b2a4ef39819acbf4ea4df99f71b0a99a7cf873e4be60087baff2" +
@@ -155,7 +155,7 @@ describe('Hash', () =>
             [ ],
             new boasdk.Hash(Buffer.alloc(boasdk.Hash.Width)),
             [ 1, 2, 3, 256, 257, 258, 70000, 80000, 90000 ],
-            BigInt(0)
+            0
         );
         assert.strictEqual(boasdk.hashFull(header).toString(),
             "0x8a69d32e2734c627f9b9c5eedf3d5515a2313ddc92314682ef5fe52951e91ea" +


### PR DESCRIPTION
We change it for compatibility with Agora.
Also avoid string JSON parsing the Bigint.
The maximum number is 2^52.
As I put it in time, it can be done until 144683.