### PR TITLE
Style: Fix variable declaration style, change enum values to hexadecimal

### DIFF
--- a/src/modules/script/Lock.ts
+++ b/src/modules/script/Lock.ts
@@ -47,17 +47,17 @@ import { SmartBuffer } from 'smart-buffer';
 export enum LockType
 {
     /// lock is a 64-byte public key, unlock is the signature
-    Key = 0,
+    Key = 0x00,
 
     /// lock is a 64-byte public key hash, unlock is a (sig, key) pair
-    KeyHash = 1,
+    KeyHash = 0x01,
 
     /// lock is a script, unlock may be anything required by the lock script
-    Script = 2,
+    Script = 0x02,
 
     /// lock is a 64-byte hash of a script, unlock is the script containing
     /// only stack pushes which will push the redeem script last
-    Redeem = 3
+    Redeem = 0x03
 }
 
 /**
@@ -68,12 +68,12 @@ export class Lock
     /**
      * Specifies the type of lock script
      */
-    public type : LockType;
+    public type: LockType;
 
     /**
      * May either be a Hash, or a sequence of opcodes
      */
-    public bytes : Buffer;
+    public bytes: Buffer;
 
     /**
      * Constructor

--- a/src/modules/script/Script.ts
+++ b/src/modules/script/Script.ts
@@ -44,7 +44,7 @@ export class Script
     /**
      * opcodes and any associated data for each push opcode
      */
-    private readonly _opcodes : Buffer;
+    private readonly _opcodes: Buffer;
 
     /**
      * Constructor


### PR DESCRIPTION
This is the PR that applied the requested modification to the previous PR(#77).
The enumeration value was changed to hexadecimal.
I fixed the style of spacing in the declaration of variables to abide by the rules.