### PR TITLE
Add a function that calculates the size of a binary serialized transaction

### DIFF
--- a/src/modules/data/Transaction.ts
+++ b/src/modules/data/Transaction.ts
@@ -123,4 +123,21 @@ export class Transaction
         Utils.writeJSBigIntLE(buf, this.lock_height.value);
         buffer.writeBuffer(buf);
     }
+
+    /**
+     * Returns the transaction size.
+     */
+    public getNumberOfBytes (): number
+    {
+        let bytes_length = Utils.SIZE_OF_BYTE + //  Transaction.type
+            this.payload.data.length +          //  Transaction.payload
+            Utils.SIZE_OF_LONG;                 //  Transaction.lock_height
+
+        for (let elem of this.inputs)
+            bytes_length += elem.getNumberOfBytes();
+        for (let elem of this.outputs)
+            bytes_length += elem.getNumberOfBytes();
+
+        return bytes_length;
+    }
 }

--- a/src/modules/data/TxInput.ts
+++ b/src/modules/data/TxInput.ts
@@ -14,6 +14,7 @@
 import { JSONValidator } from '../utils/JSONValidator';
 import { Hash, makeUTXOKey } from '../common/Hash';
 import { Unlock } from '../script/Lock';
+import { Utils } from '../utils/Utils';
 
 import JSBI from 'jsbi';
 import { SmartBuffer } from 'smart-buffer';
@@ -94,5 +95,15 @@ export class TxInput
     {
         this.utxo.computeHash(buffer);
         buffer.writeUInt32LE(this.unlock_age)
+    }
+
+    /**
+     * Returns the data size.
+     */
+    public getNumberOfBytes (): number
+    {
+        return Hash.Width +                     // TxInput.utxo
+            this.unlock.getNumberOfBytes() +    // TxInput.unlock
+            Utils.SIZE_OF_INT;                  // TxInput.unlock_age
     }
 }

--- a/src/modules/data/TxOutput.ts
+++ b/src/modules/data/TxOutput.ts
@@ -94,4 +94,13 @@ export class TxOutput
             lock: this.lock.toJSON()
         };
     }
+
+    /**
+     * Returns the data size.
+     */
+    public getNumberOfBytes (): number
+    {
+        return Utils.SIZE_OF_LONG +         //  TxOutput.value
+            this.lock.getNumberOfBytes();   //  TxOutput.lock
+    }
 }

--- a/src/modules/script/Lock.ts
+++ b/src/modules/script/Lock.ts
@@ -38,6 +38,7 @@
 import { PublicKey } from '../common/KeyPair';
 import { Signature } from '../common/Signature';
 import { JSONValidator } from '../..';
+import { Utils } from "../utils/Utils";
 
 import { SmartBuffer } from 'smart-buffer';
 
@@ -143,6 +144,15 @@ export class Lock
             bytes: this.bytes.toString("base64")
         }
     }
+
+    /**
+     * Returns the data size.
+     */
+    public getNumberOfBytes (): number
+    {
+        return Utils.SIZE_OF_BYTE + // Lock.type
+            this.bytes.length;      // Lock.bytes
+    }
 }
 
 /**
@@ -218,5 +228,13 @@ export class Unlock
         return {
             bytes: this.bytes.toString("base64")
         }
+    }
+
+    /**
+     * Returns the data size.
+     */
+    public getNumberOfBytes (): number
+    {
+        return this.bytes.length;   // Unlock.bytes
     }
 }

--- a/src/modules/utils/Utils.ts
+++ b/src/modules/utils/Utils.ts
@@ -25,6 +25,10 @@ export enum Endian
 
 export class Utils
 {
+    public static readonly SIZE_OF_BYTE: number = 1;
+    public static readonly SIZE_OF_INT: number = 4;
+    public static readonly SIZE_OF_LONG: number  = 8;
+
     /**
      * Check whether the string is a integer.
      * @param value

--- a/tests/Hash.test.ts
+++ b/tests/Hash.test.ts
@@ -91,6 +91,18 @@ describe('Hash', () =>
             "0x6dbcc8c36bd1f95986d8b06a6bad320b0719e14bb1afe2cf824618c3311a23b" +
             "5ac9c35f474dc67182cf17bb609f46e4049f793b996321f6fad88a2925badf198");
 
+        let nBytes =
+            boasdk.Utils.SIZE_OF_BYTE +     //  Transaction.type
+            boasdk.Hash.Width +             //  TxInput.utxo
+            0 +                             //  TxInput.unlock.bytes
+            boasdk.Utils.SIZE_OF_INT +      //  TxInput.unlock_age
+            boasdk.Utils.SIZE_OF_LONG +     //  TxOutput.value
+            boasdk.Utils.SIZE_OF_BYTE  +    //  TxOutput.lock.type
+            0 +                             //  TxOutput.lock.bytes
+            0 +                             //  Transaction.payload
+            boasdk.Utils.SIZE_OF_LONG;      //  Transaction.lock_height
+        assert.strictEqual(payment_tx.getNumberOfBytes(), nBytes);
+
         let freeze_tx = new boasdk.Transaction(
             boasdk.TxType.Freeze,
             [
@@ -105,6 +117,8 @@ describe('Hash', () =>
         assert.strictEqual(boasdk.hashFull(freeze_tx).toString(),
             "0xf028cecf9498bc615e3ac4ff18efa98c6428b8af1f26a2cfa73518d039a4f2e" +
             "f4f600f28cd25403ad588f0d42e3987863bbd26cdd28b136fee4b80b7f0cc061a");
+
+        assert.strictEqual(freeze_tx.getNumberOfBytes(), nBytes);
     });
 
     // See_Also: https://github.com/bpfkorea/agora/blob/73a7cd593afab6726021e05cf16b90d246343d65/source/agora/consensus/data/Block.d#L118-L138


### PR DESCRIPTION
I needed a function to return the number of bytes when the transaction was serialized to calculate the fee of the transaction.
And I wanted to get only bytes returned without serialization.
Numeric data are stored in variable sizes when serialized. 
For this purpose, I implemented a function named "Utils.getBytesInNumber".

Relates to https://github.com/bpfkorea/stoa/issues/274