### PR TITLE
Add a function that provides fees for the transactions

### DIFF
--- a/src/modules/data/Transaction.ts
+++ b/src/modules/data/Transaction.ts
@@ -140,4 +140,17 @@ export class Transaction
 
         return bytes_length;
     }
+
+    /**
+     * Returns the estimated transaction size.
+     * @param num_input The number of the inputs
+     * @param num_output The number of the outputs
+     * @param num_bytes_payload The bytes of the payload
+     */
+    public static getEstimatedNumberOfBytes (num_input: number, num_output: number, num_bytes_payload: number): number
+    {
+        return Utils.SIZE_OF_BYTE + Utils.SIZE_OF_LONG + num_bytes_payload +
+            (num_input * TxInput.getEstimatedNumberOfBytes()) +
+            (num_output * TxOutput.getEstimatedNumberOfBytes());
+    }
 }

--- a/src/modules/data/TxInput.ts
+++ b/src/modules/data/TxInput.ts
@@ -13,6 +13,7 @@
 
 import { JSONValidator } from '../utils/JSONValidator';
 import { Hash, makeUTXOKey } from '../common/Hash';
+import { Signature } from '../common/Signature';
 import { Unlock } from '../script/Lock';
 import { Utils } from '../utils/Utils';
 
@@ -105,5 +106,13 @@ export class TxInput
         return Hash.Width +                     // TxInput.utxo
             this.unlock.getNumberOfBytes() +    // TxInput.unlock
             Utils.SIZE_OF_INT;                  // TxInput.unlock_age
+    }
+
+    /**
+     * Returns the estimated data size.
+     */
+    public static getEstimatedNumberOfBytes (): number
+    {
+        return Hash.Width + Utils.SIZE_OF_INT + Signature.Width;
     }
 }

--- a/src/modules/data/TxOutput.ts
+++ b/src/modules/data/TxOutput.ts
@@ -14,6 +14,7 @@
 import { JSONValidator } from '../utils/JSONValidator';
 import { PublicKey } from '../common/KeyPair';
 import { Utils } from "../utils/Utils";
+import { SodiumHelper } from '../utils/SodiumHelper';
 import { Lock } from '../script/Lock';
 
 import JSBI from 'jsbi';
@@ -102,5 +103,13 @@ export class TxOutput
     {
         return Utils.SIZE_OF_LONG +         //  TxOutput.value
             this.lock.getNumberOfBytes();   //  TxOutput.lock
+    }
+
+    /**
+     * Returns the estimated data size.
+     */
+    public static getEstimatedNumberOfBytes (): number
+    {
+        return Utils.SIZE_OF_LONG + Utils.SIZE_OF_BYTE + Utils.SIZE_OF_PUBLIC_KEY;
     }
 }

--- a/src/modules/net/response/TrasactionFee.ts
+++ b/src/modules/net/response/TrasactionFee.ts
@@ -1,0 +1,84 @@
+/*******************************************************************************
+
+    Contains definition for the fee of the transaction
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+ *******************************************************************************/
+
+import { Utils } from '../../utils/Utils';
+
+/**
+ * Define the interface of the fee of the transaction
+ */
+export class TransactionFee
+{
+    /**
+     * The size of the transaction
+     */
+    tx_size: number;
+
+    /**
+     * The transaction fee for a medium speed
+     */
+    medium: string;
+
+    /**
+     * The transaction fee for a high speed
+     */
+    high: string;
+
+    /**
+     * The transaction fee for a low speed
+     */
+    low: string;
+
+    /**
+     * Constructor
+     * @param tx_size The size of the transaction
+     * @param medium The transaction fee for a medium speed
+     * @param high The transaction fee for a high speed
+     * @param low The transaction fee for a low speed
+     */
+    constructor (tx_size?: number, medium?: string, high?: string, low?: string)
+    {
+        if (tx_size !== undefined)
+            this.tx_size = tx_size;
+        else
+            this.tx_size = 0;
+
+        if (medium !== undefined)
+            this.medium = medium;
+        else
+            this.medium = "0.01";
+
+        if (high !== undefined)
+            this.high = high;
+        else
+            this.high = "0.01";
+
+        if (low !== undefined)
+            this.low = low;
+        else
+            this.low = "0.01";
+    }
+
+    /**
+     * This import from JSON
+     * @param data The object of the JSON
+     */
+    public fromJSON (data: any)
+    {
+        Utils.validateJSON(this, data);
+
+        this.tx_size = data.tx_size;
+        this.medium = data.medium;
+        this.high = data.high;
+        this.low = data.low;
+    }
+}

--- a/src/modules/utils/Utils.ts
+++ b/src/modules/utils/Utils.ts
@@ -32,6 +32,8 @@ export class Utils
     public static readonly SIZE_OF_SECRET_KEY: number = 64;
     public static readonly SIZE_OF_SEED_KEY: number = 32;
 
+    public static readonly FEE_FACTOR: number = 200;
+
     /**
      * Check whether the string is a integer.
      * @param value

--- a/src/modules/utils/Utils.ts
+++ b/src/modules/utils/Utils.ts
@@ -28,6 +28,9 @@ export class Utils
     public static readonly SIZE_OF_BYTE: number = 1;
     public static readonly SIZE_OF_INT: number = 4;
     public static readonly SIZE_OF_LONG: number  = 8;
+    public static readonly SIZE_OF_PUBLIC_KEY: number = 32;
+    public static readonly SIZE_OF_SECRET_KEY: number = 64;
+    public static readonly SIZE_OF_SEED_KEY: number = 32;
 
     /**
      * Check whether the string is a integer.

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -1054,32 +1054,20 @@ describe('BOA Client', () => {
         // Create UTXOManager
         let utxo_manager = new boasdk.UTXOManager(utxos);
 
-        let fee_factor = 200;
-        let estimated_input_size = boasdk.Hash.Width + boasdk.Utils.SIZE_OF_INT + boasdk.Signature.Width;
-        let estimated_output_size = boasdk.Utils.SIZE_OF_LONG + boasdk.Utils.SIZE_OF_BYTE + boasdk.SodiumHelper.sodium.crypto_sign_PUBLICKEYBYTES;
-        let estimated_tx_size = boasdk.Utils.SIZE_OF_BYTE + boasdk.Utils.SIZE_OF_LONG;
-
-        let getTxEstimatedNumberOfBytes = (num_input: number, num_output: number, num_bytes_payload: number): number =>
-        {
-            return estimated_tx_size + num_bytes_payload +
-                num_input * estimated_input_size +
-                num_output + estimated_output_size;
-        }
-
         let output_address = "GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW";
         let output_count = 2;
-        let estimated_tx_fee = JSBI.BigInt(fee_factor *
-            getTxEstimatedNumberOfBytes(0, output_count, vote_data.data.length));
+        let estimated_tx_fee = JSBI.BigInt(boasdk.Utils.FEE_FACTOR *
+            boasdk.Transaction.getEstimatedNumberOfBytes(0, output_count, vote_data.data.length));
 
         let send_boa = JSBI.BigInt(200000);
         let total_fee = JSBI.add(payload_fee, estimated_tx_fee);
         let total_send_amount = JSBI.add(total_fee, send_boa);
 
         let in_utxos = utxo_manager.getUTXO(total_send_amount, block_height,
-            JSBI.BigInt(fee_factor * estimated_input_size));
+            JSBI.BigInt(boasdk.Utils.FEE_FACTOR * boasdk.TxInput.getEstimatedNumberOfBytes()));
         in_utxos.forEach((u: boasdk.UnspentTxOutput) => builder.addInput(u.utxo, u.amount));
-        estimated_tx_fee = JSBI.BigInt(fee_factor *
-            getTxEstimatedNumberOfBytes(in_utxos.length, output_count, vote_data.data.length));
+        estimated_tx_fee = JSBI.BigInt(boasdk.Utils.FEE_FACTOR *
+            boasdk.Transaction.getEstimatedNumberOfBytes(in_utxos.length, output_count, vote_data.data.length));
 
         // Build a transaction
         let tx = builder
@@ -1107,11 +1095,11 @@ describe('BOA Client', () => {
             in_utxos.push(
                 ...utxo_manager.getUTXO(JSBI.subtract(total_send_amount, sum_amount_utxo),
                     block_height,
-                    JSBI.BigInt(fee_factor * estimated_input_size))
+                    JSBI.BigInt(boasdk.Utils.FEE_FACTOR * boasdk.TxInput.getEstimatedNumberOfBytes()))
             );
             in_utxos.forEach((u: boasdk.UnspentTxOutput) => builder.addInput(u.utxo, u.amount));
-            estimated_tx_fee = JSBI.BigInt(fee_factor *
-                getTxEstimatedNumberOfBytes(in_utxos.length, output_count, vote_data.data.length));
+            estimated_tx_fee = JSBI.BigInt(boasdk.Utils.FEE_FACTOR *
+                boasdk.Transaction.getEstimatedNumberOfBytes(in_utxos.length, output_count, vote_data.data.length));
 
             // Build a transaction
             tx = builder

--- a/tests/Transaction.test.ts
+++ b/tests/Transaction.test.ts
@@ -1,0 +1,31 @@
+/*******************************************************************************
+
+    Test of Transaction
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+ *******************************************************************************/
+
+import * as boasdk from '../lib';
+
+import * as assert from 'assert';
+
+describe ('Transaction', () =>
+{
+    before ('Wait for the package libsodium to finish loading', () =>
+    {
+        return boasdk.SodiumHelper.init();
+    });
+
+    it ('Test of estimated size', () =>
+    {
+        assert.strictEqual(boasdk.TxInput.getEstimatedNumberOfBytes(), 132);
+        assert.strictEqual(boasdk.TxOutput.getEstimatedNumberOfBytes(), 41);
+        assert.strictEqual(boasdk.Transaction.getEstimatedNumberOfBytes(0, 0, 0), 9);
+    });
+});

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -14,6 +14,7 @@
 import * as boasdk from '../lib';
 
 import * as assert from 'assert';
+import {SodiumHelper} from "../src";
 
 describe ('Test of isInteger, isPositiveInteger, isNegativeInteger', () =>
 {
@@ -61,6 +62,11 @@ describe ('Test for JSON serialization', () =>
 
 describe ('Test of Utils', () =>
 {
+    before('Wait for the package libsodium to finish loading', async () =>
+    {
+        await boasdk.SodiumHelper.init();
+    });
+
     it('Test of Utils.compareBuffer', () =>
     {
         let a = Buffer.from([6, 3, 2, 1]);
@@ -81,5 +87,12 @@ describe ('Test of Utils', () =>
         let y = Buffer.from([6, 5, 4, 3, 4, 1]);
         assert.ok(boasdk.Utils.compareBuffer(x, y) < 0);
         assert.ok(boasdk.Utils.compareBuffer(y, x) > 0);
+    });
+
+    it ('Test of sizeof keys', () =>
+    {
+        assert.strictEqual(boasdk.Utils.SIZE_OF_PUBLIC_KEY, boasdk.SodiumHelper.sodium.crypto_sign_PUBLICKEYBYTES);
+        assert.strictEqual(boasdk.Utils.SIZE_OF_SECRET_KEY, boasdk.SodiumHelper.sodium.crypto_sign_SECRETKEYBYTES);
+        assert.strictEqual(boasdk.Utils.SIZE_OF_SEED_KEY, boasdk.SodiumHelper.sodium.crypto_sign_SEEDBYTES);
     });
 });


### PR DESCRIPTION
Fees increase with the size of the transaction.
When an endpoint is added to Stoa, It will be changed to use the endpoint of Stoa to obtain transaction fees.

Relates to https://github.com/bpfkorea/stoa/issues/274
