### PR TITLE
Upgrade version to 0.0.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "The TypeScript BOA SDK library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
The ability to calculate the recently updated transaction size needs to be used in Stoa, so an upgrade to the version is required.