### PR TITLE
Bug fix: The operation of JSBI must use static function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "The TypeScript BOA SDK library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/modules/utils/UTXOManager.ts
+++ b/src/modules/utils/UTXOManager.ts
@@ -123,7 +123,7 @@ export class UTXOManager
                 && JSBI.lessThanOrEqual(JSBI.subtract(n.unlock_height, JSBI.BigInt(1)), height)))
             .filter((n) =>
             {
-                if (sum >= amount)
+                if (JSBI.greaterThanOrEqual(sum, amount))
                     return false;
                 sum = JSBI.add(sum, n.amount);
                 n.used = true;


### PR DESCRIPTION
The comparison between instances of JSBI should use a static function. However, because they did not do so, they had wrong results.