### PR TITLE
Bug Fix: Cause an error when the block height is 0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "The TypeScript BOA SDK library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/modules/utils/UTXOManager.ts
+++ b/src/modules/utils/UTXOManager.ts
@@ -83,8 +83,8 @@ export class UTXOManager
      */
     public getSum (height?: JSBI): [JSBI, JSBI, JSBI]
     {
-        if ((height !== undefined) && JSBI.lessThanOrEqual(height, JSBI.BigInt(0)))
-            throw new Error(`Positive height expected, not ${height.toString()}`);
+        if ((height !== undefined) && JSBI.lessThan(height, JSBI.BigInt(0)))
+            throw new Error(`The height must be greater than or equal to zero, not ${height.toString()}`);
 
         return this.items
             .filter(n => !n.used)
@@ -113,8 +113,8 @@ export class UTXOManager
         if (JSBI.lessThanOrEqual(target_amount, JSBI.BigInt(0)))
             throw new Error(`Positive amount expected, not ${target_amount.toString()}`);
 
-        if (JSBI.lessThanOrEqual(height, JSBI.BigInt(0)))
-            throw new Error(`Positive height expected, not ${height.toString()}`);
+        if (JSBI.lessThan(height, JSBI.BigInt(0)))
+            throw new Error(`The height must be greater than or equal to zero, not ${height.toString()}`);
 
         if (JSBI.greaterThan(target_amount, this.getSum(height)[TxType.Payment]))
             return [];


### PR DESCRIPTION
This does not make sense because the height of the block can be zero. So I fixed the bug.