### PR TITLE
Change the JSON serialization method of BitField

### DIFF
--- a/src/modules/data/BitField.ts
+++ b/src/modules/data/BitField.ts
@@ -54,4 +54,12 @@ export class BitField
 
         return new BitField(storage);
     }
+
+    /**
+     * Converts this object to its JSON representation
+     */
+    public toJSON (key?: string): string
+    {
+        return JSON.stringify(this.storage);
+    }
 }

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -95,4 +95,10 @@ describe ('Test of Utils', () =>
         assert.strictEqual(boasdk.Utils.SIZE_OF_SECRET_KEY, boasdk.SodiumHelper.sodium.crypto_sign_SECRETKEYBYTES);
         assert.strictEqual(boasdk.Utils.SIZE_OF_SEED_KEY, boasdk.SodiumHelper.sodium.crypto_sign_SEEDBYTES);
     });
+
+    it ('Test of BitField JSON serialization', () =>
+    {
+        let validator = new boasdk.BitField([45, 90, 150]);
+        assert.strictEqual(JSON.stringify(validator), `"[45,90,150]"`);
+    });
 });

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -14,7 +14,6 @@
 import * as boasdk from '../lib';
 
 import * as assert from 'assert';
-import {SodiumHelper} from "../src";
 
 describe ('Test of isInteger, isPositiveInteger, isNegativeInteger', () =>
 {


### PR DESCRIPTION
In Agora, BitField was expressed as a string in JSON. I modified it to make it the same as that.
ex)
```
"validators": "[252]",
```