### PR TITLE
Add the ability to request a transaction based on a hash of a transaction

### DIFF
--- a/src/modules/net/BOAClient.ts
+++ b/src/modules/net/BOAClient.ts
@@ -503,6 +503,41 @@ export class BOAClient
                 });
         });
     }
+
+    /**
+     * Request a transaction based on the hash of the transaction.
+     * @param tx_hash The hash of the transaction
+     * @returns Promise that resolves or
+     * rejects with response from the Stoa
+     */
+    public getTransaction (tx_hash: Hash): Promise<Transaction>
+    {
+        return new Promise<Transaction>((resolve, reject) =>
+        {
+            let url = uri(this.server_url)
+                .directory("transaction")
+                .filename(tx_hash.toString());
+
+            Request.get(url.toString())
+                .then((response: AxiosResponse) =>
+                {
+                    if (response.status == 200)
+                    {
+                        let tx = Transaction.reviver("",response.data)
+                        resolve(tx);
+                    }
+                    else
+                    {
+                        // It is not yet defined in Stoa.
+                        reject(handleNetworkError({response: response}));
+                    }
+                })
+                .catch((reason: any) =>
+                {
+                    reject(handleNetworkError(reason));
+                });
+        });
+    }
 }
 
 export interface IsValidPreimageResponse

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -582,6 +582,37 @@ export class TestStoa {
                 }
             });
 
+        // http://localhost/transaction
+        this.app.get("/transaction/:hash",
+            (req: express.Request, res: express.Response) => {
+
+                let hash: string = String(req.params.hash);
+
+                let tx_hash: boasdk.Hash;
+                try
+                {
+                    tx_hash = new boasdk.Hash(hash);
+                }
+                catch (error)
+                {
+                    res.status(400).send(`Invalid value for parameter 'hash': ${hash}`);
+                    return;
+                }
+
+                let sample_tx_hash = new boasdk.Hash(
+                    "0x4c1d71415c9ec7b182438e8bb669e324dde9be93b9c223a2ca831689d2e9598" +
+                    "c628d07c84d3ee0941e9f6fb597faf4fe92518fa35e577ba12125919c0501d4bd");
+
+                if (Buffer.compare(tx_hash.data, sample_tx_hash.data) != 0)
+                {
+                    res.status(204).send(`No pending transactions. hash': (${hash})`);
+                }
+                else
+                {
+                    res.status(200).send(JSON.stringify(sample_tx));
+                }
+            });
+
         this.app.set('port', this.port);
 
         // Listen on provided this.port on this.address.
@@ -1530,6 +1561,22 @@ describe('BOA Client', () => {
             "0x4c1d71415c9ec7b182438e8bb669e324dde9be93b9c223a2ca831689d2e9598" +
             "c628d07c84d3ee0941e9f6fb597faf4fe92518fa35e577ba12125919c0501d4bd");
         let tx = await boa_client.getPendingTransaction(tx_hash);
+        assert.deepStrictEqual(tx, boasdk.Transaction.reviver("", sample_tx));
+    });
+
+    it ('Test a function of the BOA Client - `getTransaction`', async () =>
+    {
+        // Set URL
+        let stoa_uri = URI("http://localhost").port(stoa_port);
+        let agora_uri = URI("http://localhost").port(agora_port);
+
+        // Create BOA Client
+        let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
+
+        let tx_hash = new boasdk.Hash(
+            "0x4c1d71415c9ec7b182438e8bb669e324dde9be93b9c223a2ca831689d2e9598" +
+            "c628d07c84d3ee0941e9f6fb597faf4fe92518fa35e577ba12125919c0501d4bd");
+        let tx = await boa_client.getTransaction(tx_hash);
         assert.deepStrictEqual(tx, boasdk.Transaction.reviver("", sample_tx));
     });
 });


### PR DESCRIPTION
I added the ability to query one transaction using Stoa's endpoint '/transaction/:hash' to the BOAClient.